### PR TITLE
Missing spacing on the reject confirmation prompt

### DIFF
--- a/src/commands/mod/loggable/Reject.ts
+++ b/src/commands/mod/loggable/Reject.ts
@@ -39,7 +39,7 @@ export default class Reject extends Command<ModBot>
 			.then((res: Message) => res.delete(5e3));
 
 		const [result, ask, confirmation]: [PromptResult, Message, Message] = await prompt(message,
-			`Are you sure you want to reject appeal \`${id}\` with this reason? (__y__es|__n__o)`,
+			`Are you sure you want to reject appeal \`${id}\` with this reason? (__y__es | __n__o)`,
 			/^(?:yes|y)$/i, /^(?:no|n)$/i);
 
 		if (result === PromptResult.TIMEOUT)


### PR DESCRIPTION
Looks odd that there's no spacing between the options, this should take care of it.